### PR TITLE
Define dash to be part of an unquoted string

### DIFF
--- a/syntax/hocon.vim
+++ b/syntax/hocon.vim
@@ -64,7 +64,7 @@ syn match hoconUnit "Y\>\|y\|Yi\>\|YiB\>\|yobibyte\>\|yobibytes\>" contained
 
 syn region hoconVariable start="\${" end="}"
 
-syn match hoconUnquotedString '[a-zA-Z_][a-zA-Z0-9_.]*'
+syn match hoconUnquotedString '[a-zA-Z_][a-zA-Z0-9_.-]*'
 
 syn keyword hoconKeyword include nextgroup=hoconString skipwhite
 


### PR DESCRIPTION
See GEverding/vim-hocon#1 – perhaps we can ask the repo owner to take that down / direct people here, as you're the author of the syntax file and your repo contains a license. This dash is the only difference in the syntax file between the two.